### PR TITLE
[R1295] - update core module with latest api spec

### DIFF
--- a/RyftCore/Source/Api/AttemptPaymentRequest.swift
+++ b/RyftCore/Source/Api/AttemptPaymentRequest.swift
@@ -3,6 +3,7 @@ public struct AttemptPaymentRequest {
     let clientSecret: String
     let cardDetails: PaymentRequestCardDetails?
     let walletDetails: PaymentRequestWalletDetails?
+    let billingAddress: BillingAddress?
 
     public static func fromCard(
         clientSecret: String,
@@ -19,13 +20,15 @@ public struct AttemptPaymentRequest {
                 expiryYear: expiryYear,
                 cvc: cvc
             ),
-            walletDetails: nil
+            walletDetails: nil,
+            billingAddress: nil
         )
     }
 
     public static func fromApplePay(
         clientSecret: String,
-        applePayToken: String
+        applePayToken: String,
+        billingAddress: BillingAddress?
     ) -> AttemptPaymentRequest {
         AttemptPaymentRequest(
             clientSecret: clientSecret,
@@ -33,7 +36,8 @@ public struct AttemptPaymentRequest {
             walletDetails: PaymentRequestWalletDetails(
                 type: "ApplePay",
                 applePayToken: applePayToken
-            )
+            ),
+            billingAddress: billingAddress
         )
     }
 
@@ -100,6 +104,9 @@ public struct AttemptPaymentRequest {
         }
         if let walletDetails = walletDetails {
             json["walletDetails"] = walletDetails.toJson() as Any
+        }
+        if let billingAddress = billingAddress {
+            json["billingAddress"] = billingAddress.toJson() as Any
         }
         return json
     }

--- a/RyftCore/Source/Api/AttemptPaymentRequest.swift
+++ b/RyftCore/Source/Api/AttemptPaymentRequest.swift
@@ -2,6 +2,7 @@ public struct AttemptPaymentRequest {
 
     let clientSecret: String
     let cardDetails: PaymentRequestCardDetails?
+    let walletDetails: PaymentRequestWalletDetails?
 
     public static func fromCard(
         clientSecret: String,
@@ -17,6 +18,21 @@ public struct AttemptPaymentRequest {
                 expiryMonth: expiryMonth,
                 expiryYear: expiryYear,
                 cvc: cvc
+            ),
+            walletDetails: nil
+        )
+    }
+
+    public static func fromApplePay(
+        clientSecret: String,
+        applePayToken: String
+    ) -> AttemptPaymentRequest {
+        AttemptPaymentRequest(
+            clientSecret: clientSecret,
+            cardDetails: nil,
+            walletDetails: PaymentRequestWalletDetails(
+                type: "ApplePay",
+                applePayToken: applePayToken
             )
         )
     }
@@ -29,7 +45,7 @@ public struct AttemptPaymentRequest {
         let cvc: String
 
         func toJson() -> [String: Any] {
-            return [
+            [
                 "number": number,
                 "expiryMonth": expiryMonth,
                 "expiryYear": expiryYear,
@@ -52,12 +68,38 @@ public struct AttemptPaymentRequest {
         }
     }
 
+    public struct PaymentRequestWalletDetails: Equatable, Hashable {
+
+        let type: String
+        let applePayToken: String
+
+        func toJson() -> [String: Any] {
+            [
+                "type": type,
+                "applePayToken": applePayToken
+            ]
+        }
+
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(type)
+            hasher.combine(applePayToken)
+        }
+
+        public static func == (lhs: PaymentRequestWalletDetails, rhs: PaymentRequestWalletDetails) -> Bool {
+            return lhs.type == rhs.type
+                && lhs.applePayToken == rhs.applePayToken
+        }
+    }
+
     func toJson() -> [String: Any] {
         var json: [String: Any] = [
             "clientSecret": clientSecret
         ]
         if let card = cardDetails {
             json["cardDetails"] = card.toJson() as Any
+        }
+        if let walletDetails = walletDetails {
+            json["walletDetails"] = walletDetails.toJson() as Any
         }
         return json
     }

--- a/RyftCore/Source/Api/BillingAddress.swift
+++ b/RyftCore/Source/Api/BillingAddress.swift
@@ -1,0 +1,68 @@
+public struct BillingAddress: Equatable, Hashable {
+
+    public let firstName: String?
+    public let lastName: String?
+    public let lineOne: String?
+    public let lineTwo: String?
+    public let city: String?
+    public let country: String
+    public let postalCode: String
+    public let region: String?
+
+    public init(
+        firstName: String?,
+        lastName: String?,
+        lineOne: String?,
+        lineTwo: String?,
+        city: String?,
+        country: String,
+        postalCode: String,
+        region: String?
+    ) {
+        self.firstName = firstName
+        self.lastName = lastName
+        self.lineOne = lineOne
+        self.lineTwo = lineTwo
+        self.city = city
+        self.country = country
+        self.postalCode = postalCode
+        self.region = region
+    }
+
+    func toJson() -> [String: Any] {
+        let json =
+        [
+            "firstName": firstName as Any?,
+            "lastName": lastName as Any?,
+            "lineOne": lineOne as Any?,
+            "lineTwo": lineTwo as Any?,
+            "city": city as Any?,
+            "country": country,
+            "postalCode": postalCode,
+            "region": region as Any?
+        ]
+        return json.compactMapValues { $0 }
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(firstName)
+        hasher.combine(lastName)
+        hasher.combine(lineOne)
+        hasher.combine(lineTwo)
+        hasher.combine(city)
+        hasher.combine(country)
+        hasher.combine(postalCode)
+        hasher.combine(region)
+    }
+
+    public static func == (lhs: BillingAddress, rhs: BillingAddress) -> Bool {
+        lhs.firstName == rhs.firstName
+            && lhs.lastName == rhs.lastName
+            && lhs.lineOne == rhs.lineOne
+            && lhs.lineTwo == rhs.lineTwo
+            && lhs.city == rhs.city
+            && lhs.country == rhs.country
+            && lhs.postalCode == rhs.postalCode
+            && lhs.region == rhs.region
+    }
+}

--- a/RyftCore/Source/Models/Currency.swift
+++ b/RyftCore/Source/Models/Currency.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+public struct Currency: Equatable, Hashable {
+
+    public let code: String
+    public let minorUnits: Int
+
+    init(code: String, minorUnits: Int) {
+        self.code = code
+        self.minorUnits = minorUnits
+    }
+
+    public func dividor() -> Double {
+        return NSDecimalNumber(decimal: pow(10, minorUnits)).doubleValue
+    }
+
+    public static func from(code: String) -> Currency {
+        assert(allCurrencyCodes.contains(code), "code must be a valid ISO 4217 alphabetic code")
+        return Currency(
+            code: code,
+            minorUnits: CurrencyUtility.minorUnits(from: code)
+        )
+    }
+
+    public static func == (lhs: Currency, rhs: Currency) -> Bool {
+        return lhs.code == rhs.code &&
+            lhs.minorUnits == rhs.minorUnits
+    }
+
+    public static let allCurrencyCodes = Set(Locale.isoCurrencyCodes)
+}

--- a/RyftCore/Source/Models/Money.swift
+++ b/RyftCore/Source/Models/Money.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+public struct Money: Equatable, Hashable {
+
+    public let currency: Currency
+    public let amount: Int
+
+    public init(currency: Currency, amount: Int) {
+        self.currency = currency
+        self.amount = amount
+    }
+
+    public init(currencyCode: String, amount: Int) {
+        self.currency = Currency.from(code: currencyCode)
+        self.amount = amount
+    }
+
+    public func calculatePercentageAmount(with percentage: Double) -> Money {
+        let intermediateResult = calculatePercentagePreservingDecimal(percentage: percentage)
+        return Money(currency: self.currency, amount: Int(intermediateResult))
+    }
+
+    public func amountInMajorUnits() -> NSDecimalNumber {
+        return NSDecimalNumber(decimal: Decimal(amount) / Decimal(currency.dividor()))
+    }
+
+    public static func + (money: Money, pennies: Int) -> Money {
+        return money + Money(currency: money.currency, amount: pennies)
+    }
+
+    public static func + (left: Money, maybeRight: Money?) -> Money {
+        return left + (maybeRight ?? Money(currency: left.currency, amount: 0))
+    }
+
+    public static func + (left: Money, right: Money) -> Money {
+        return Money(currency: left.currency, amount: left.amount + right.amount)
+    }
+
+    public static func - (left: Money, right: Money) -> Money {
+        return Money(currency: left.currency, amount: left.amount - right.amount)
+    }
+
+    public static func > (left: Money, right: Money) -> Bool {
+        return left.amount > right.amount
+    }
+
+    public static func > (left: Money, right: Int) -> Bool {
+        return left.amount > right
+    }
+
+    public static func < (left: Money, right: Money) -> Bool {
+        return left.amount < right.amount
+    }
+
+    public static func * (multiplier: Int, money: Money) -> Money {
+        return Money(currency: money.currency, amount: money.amount * multiplier)
+    }
+
+    public static func * (money: Money, multiplier: Int) -> Money {
+        return Money(currency: money.currency, amount: money.amount * multiplier)
+    }
+
+    private func calculatePercentagePreservingDecimal(percentage: Double) -> Double {
+        return (Double(amount) * (percentage / currency.dividor()))
+    }
+
+    static func from(_ amount: Int, currencyCode: String) -> Money {
+        let currency = Currency.from(code: currencyCode)
+        return Money(currency: currency, amount: amount)
+    }
+
+    public static func == (lhs: Money, rhs: Money) -> Bool {
+        return lhs.currency == rhs.currency &&
+            lhs.amount == rhs.amount
+    }
+}

--- a/RyftCore/Source/Models/PaymentSession.swift
+++ b/RyftCore/Source/Models/PaymentSession.swift
@@ -1,14 +1,22 @@
 public struct PaymentSession: Codable {
 
     public let id: String
+    public let amount: Int
+    public let currency: String
     public let status: PaymentSessionStatus
     public let lastError: PaymentSessionError?
     public let requiredAction: PaymentSessionRequiredAction?
     public let returnUrl: String
     public let createdTimestamp: Int64
 
+    public func amountAsMoney() -> Money {
+        Money(currencyCode: currency, amount: amount)
+    }
+
     enum CodingKeys: String, CodingKey {
         case id
+        case amount
+        case currency
         case status
         case lastError
         case requiredAction

--- a/RyftCore/Source/Utility/CurrencyUtility.swift
+++ b/RyftCore/Source/Utility/CurrencyUtility.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public final class CurrencyUtility {
+
+    public static func minorUnits(from alphabeticCurrencyCode: String) -> Int {
+        switch alphabeticCurrencyCode {
+        case "BIF", "CLP":
+            return 0
+        case "AFN", "ALL", "COP", "IDR", "IRR", "KPW", "LAK", "LBP", "MMK", "MGA", "PKR", "RSD", "SYP", "SOS", "SLL", "YER":
+            return 2
+        case "BHD", "IQD":
+            return 3
+        default:
+            return currencyFormatter(
+                currencyCode: alphabeticCurrencyCode
+            ).maximumFractionDigits
+        }
+    }
+
+    private static func currencyFormatter(currencyCode: String) -> NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = currencyCode
+        return formatter
+    }
+}

--- a/RyftCore/Source/Utility/CurrencyUtility.swift
+++ b/RyftCore/Source/Utility/CurrencyUtility.swift
@@ -6,7 +6,8 @@ public final class CurrencyUtility {
         switch alphabeticCurrencyCode {
         case "BIF", "CLP":
             return 0
-        case "AFN", "ALL", "COP", "IDR", "IRR", "KPW", "LAK", "LBP", "MMK", "MGA", "PKR", "RSD", "SYP", "SOS", "SLL", "YER":
+        case "AFN", "ALL", "COP", "IDR", "IRR", "KPW", "LAK", "LBP",
+            "MMK", "MGA", "PKR", "RSD", "SYP", "SOS", "SLL", "YER":
             return 2
         case "BHD", "IQD":
             return 3

--- a/RyftCoreTests/Api/AttemptPaymentRequestTest.swift
+++ b/RyftCoreTests/Api/AttemptPaymentRequestTest.swift
@@ -26,7 +26,8 @@ class AttemptPaymentRequestTest: XCTestCase {
     func test_fromApplePay_shouldReturnExpectedValue() {
         let value = AttemptPaymentRequest.fromApplePay(
             clientSecret: "secret",
-            applePayToken: "base64-encoded-apple-pay-token"
+            applePayToken: "base64-encoded-apple-pay-token",
+            billingAddress: nil
         )
         let expectedWalletDetails = AttemptPaymentRequest.PaymentRequestWalletDetails(
             type: "ApplePay",
@@ -75,7 +76,8 @@ class AttemptPaymentRequestTest: XCTestCase {
     func test_toJson_shouldReturnExpectedValue_forApplePayPayment() {
         let result = AttemptPaymentRequest.fromApplePay(
             clientSecret: "secret",
-            applePayToken: "base64-encoded-apple-pay-token"
+            applePayToken: "base64-encoded-apple-pay-token",
+            billingAddress: nil
         ).toJson()
         XCTAssertNotNil(result["clientSecret"])
         XCTAssertNotNil(result["walletDetails"])
@@ -98,5 +100,28 @@ class AttemptPaymentRequestTest: XCTestCase {
         XCTAssertEqual("secret", clientSecret)
         XCTAssertEqual("ApplePay", walletType)
         XCTAssertEqual("base64-encoded-apple-pay-token", applePayToken)
+    }
+
+    func test_toJson_shouldIncludeBillingAddress_whenItIsPresent() {
+        let billingAddress = TestFixtures.billingAddress()
+        let result = AttemptPaymentRequest.fromApplePay(
+            clientSecret: "secret",
+            applePayToken: "base64-encoded-apple-pay-token",
+            billingAddress: billingAddress
+        ).toJson()
+        XCTAssertNotNil(result["billingAddress"])
+        guard let billingAddressJson = result["billingAddress"] as? [String: Any] else {
+            XCTFail("serialized JSON billingAddress field was not expected type")
+            return
+        }
+        guard
+            let country = billingAddressJson["country"] as? String,
+            let postalCode = billingAddressJson["postalCode"] as? String
+        else {
+            XCTFail("serialized JSON billingAddress did not contain the expected fields")
+            return
+        }
+        XCTAssertEqual(billingAddress.country, country)
+        XCTAssertEqual(billingAddress.postalCode, postalCode)
     }
 }

--- a/RyftCoreTests/Api/AttemptPaymentRequestTest.swift
+++ b/RyftCoreTests/Api/AttemptPaymentRequestTest.swift
@@ -20,9 +20,24 @@ class AttemptPaymentRequestTest: XCTestCase {
         )
         XCTAssertTrue(value.clientSecret == "secret")
         XCTAssertTrue(value.cardDetails == expectedCardDetails)
+        XCTAssertNil(value.walletDetails)
     }
 
-    func test_toJson_shouldReturnExpectedValue() {
+    func test_fromApplePay_shouldReturnExpectedValue() {
+        let value = AttemptPaymentRequest.fromApplePay(
+            clientSecret: "secret",
+            applePayToken: "base64-encoded-apple-pay-token"
+        )
+        let expectedWalletDetails = AttemptPaymentRequest.PaymentRequestWalletDetails(
+            type: "ApplePay",
+            applePayToken: "base64-encoded-apple-pay-token"
+        )
+        XCTAssertTrue(value.clientSecret == "secret")
+        XCTAssertTrue(value.walletDetails == expectedWalletDetails)
+        XCTAssertNil(value.cardDetails)
+    }
+
+    func test_toJson_shouldReturnExpectedValue_forCardPayment() {
         let result = AttemptPaymentRequest.fromCard(
             clientSecret: "secret",
             number: "4242424242424242",
@@ -32,6 +47,7 @@ class AttemptPaymentRequestTest: XCTestCase {
         ).toJson()
         XCTAssertNotNil(result["clientSecret"])
         XCTAssertNotNil(result["cardDetails"])
+        XCTAssertNil(result["walletDetails"])
         guard let clientSecret = result["clientSecret"] as? String else {
             XCTFail("serialized JSON clientSecret field was not expected type")
             return
@@ -54,5 +70,33 @@ class AttemptPaymentRequestTest: XCTestCase {
         XCTAssertEqual("10", cardExpiryMonth)
         XCTAssertEqual("2028", cardExpiryYear)
         XCTAssertEqual("100", cardCvc)
+    }
+
+    func test_toJson_shouldReturnExpectedValue_forApplePayPayment() {
+        let result = AttemptPaymentRequest.fromApplePay(
+            clientSecret: "secret",
+            applePayToken: "base64-encoded-apple-pay-token"
+        ).toJson()
+        XCTAssertNotNil(result["clientSecret"])
+        XCTAssertNotNil(result["walletDetails"])
+        XCTAssertNil(result["cardDetails"])
+        guard let clientSecret = result["clientSecret"] as? String else {
+            XCTFail("serialized JSON clientSecret field was not expected type")
+            return
+        }
+        guard let walletDetails = result["walletDetails"] as? [String: Any] else {
+            XCTFail("serialized JSON walletDetails field was not expected type")
+            return
+        }
+        guard
+            let walletType = walletDetails["type"] as? String,
+            let applePayToken = walletDetails["applePayToken"] as? String
+        else {
+            XCTFail("serialized JSON walletDetails did not contain the expected fields")
+            return
+        }
+        XCTAssertEqual("secret", clientSecret)
+        XCTAssertEqual("ApplePay", walletType)
+        XCTAssertEqual("base64-encoded-apple-pay-token", applePayToken)
     }
 }

--- a/RyftCoreTests/Api/BillingAddressTests.swift
+++ b/RyftCoreTests/Api/BillingAddressTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+
+@testable import RyftCore
+
+class BillingAddressTests: XCTestCase {
+
+    func test_toJson_shouldReturnExpectedValue_whenNilFieldsAreMissing() {
+        let billingAddress = TestFixtures.billingAddress()
+        let result = billingAddress.toJson()
+        XCTAssertNil(result["firstName"])
+        XCTAssertNil(result["lastName"])
+        XCTAssertNil(result["lineOne"])
+        XCTAssertNil(result["lineTwo"])
+        XCTAssertNil(result["city"])
+        XCTAssertNil(result["region"])
+        guard let country = result["country"] as? String else {
+            XCTFail("serialized JSON country field was not expected type")
+            return
+        }
+        guard let postalCode = result["postalCode"] as? String else {
+            XCTFail("serialized JSON postalCode field was not expected type")
+            return
+        }
+        XCTAssertEqual("US", country)
+        XCTAssertEqual("94043", postalCode)
+    }
+
+    // swiftlint:disable function_body_length
+    func test_toJson_shouldReturnExpectedValue_whenNilFieldsArePresent() {
+        let billingAddress = BillingAddress(
+            firstName: "John",
+            lastName: "Doe",
+            lineOne: "c/o Google LLC",
+            lineTwo: "1600 Amphitheatre Pkwy",
+            city: "Mountain View",
+            country: "US",
+            postalCode: "94043",
+            region: "CA"
+        )
+        let result = billingAddress.toJson()
+        XCTAssertNotNil(result["firstName"])
+        XCTAssertNotNil(result["lastName"])
+        XCTAssertNotNil(result["lineOne"])
+        XCTAssertNotNil(result["lineTwo"])
+        XCTAssertNotNil(result["city"])
+        XCTAssertNotNil(result["region"])
+        guard let firstName = result["firstName"] as? String else {
+            XCTFail("serialized JSON firstName field was not expected type")
+            return
+        }
+        guard let lastName = result["lastName"] as? String else {
+            XCTFail("serialized JSON lastName field was not expected type")
+            return
+        }
+        guard let lineOne = result["lineOne"] as? String else {
+            XCTFail("serialized JSON lineOne field was not expected type")
+            return
+        }
+        guard let lineTwo = result["lineTwo"] as? String else {
+            XCTFail("serialized JSON lineTwo field was not expected type")
+            return
+        }
+        guard let city = result["city"] as? String else {
+            XCTFail("serialized JSON city field was not expected type")
+            return
+        }
+        guard let country = result["country"] as? String else {
+            XCTFail("serialized JSON country field was not expected type")
+            return
+        }
+        guard let postalCode = result["postalCode"] as? String else {
+            XCTFail("serialized JSON postalCode field was not expected type")
+            return
+        }
+        guard let region = result["region"] as? String else {
+            XCTFail("serialized JSON region field was not expected type")
+            return
+        }
+        XCTAssertEqual("John", firstName)
+        XCTAssertEqual("Doe", lastName)
+        XCTAssertEqual("c/o Google LLC", lineOne)
+        XCTAssertEqual("1600 Amphitheatre Pkwy", lineTwo)
+        XCTAssertEqual("Mountain View", city)
+        XCTAssertEqual("US", country)
+        XCTAssertEqual("94043", postalCode)
+        XCTAssertEqual("CA", region)
+    }
+    // swiftlint:enable function_body_length
+}

--- a/RyftCoreTests/Models/CurrencyTests.swift
+++ b/RyftCoreTests/Models/CurrencyTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+
+@testable import RyftCore
+
+class CurrencyTests: XCTestCase {
+
+    func test_fromCode_shouldReturnExpectedCurrencyForGBP() {
+        XCTAssertEqual(Currency.from(code: "GBP"), Currency(code: "GBP", minorUnits: 2))
+    }
+
+    func test_fromCode_shouldReturnExpectedCurrencyForEUR() {
+        XCTAssertEqual(Currency.from(code: "EUR"), Currency(code: "EUR", minorUnits: 2))
+    }
+
+    func test_dividor_shouldReturnExpectedValue_forGBP() {
+        XCTAssertEqual(Currency.from(code: "GBP").dividor(), 100)
+    }
+
+    func test_dividor_shouldReturnExpectedValue_forEUR() {
+        XCTAssertEqual(Currency.from(code: "EUR").dividor(), 100)
+    }
+
+    func test_equatable_shouldReturnFalse_whenDigitsDiffer() {
+        let first = Currency(code: "GBP", minorUnits: 2)
+        let second = Currency(code: "GBP", minorUnits: 4)
+        XCTAssertNotEqual(first, second)
+    }
+
+    func test_equatable_shouldReturnFalse_whenCodeDiffers() {
+        let first = Currency(code: "GBP", minorUnits: 2)
+        let second = Currency(code: "EUR", minorUnits: 2)
+        XCTAssertNotEqual(first, second)
+    }
+
+    func test_equatable_shouldReturnTrue_whenNoFieldsDiffer() {
+        let first = Currency(code: "GBP", minorUnits: 2)
+        let second = Currency(code: "GBP", minorUnits: 2)
+        XCTAssertEqual(first, second)
+    }
+}

--- a/RyftCoreTests/Models/MoneyTests.swift
+++ b/RyftCoreTests/Models/MoneyTests.swift
@@ -1,0 +1,151 @@
+import XCTest
+
+@testable import RyftCore
+
+class MoneyTests: XCTestCase {
+
+    func test_fromAmountAndCode_shouldReturnExpectedValue() {
+        let expected = Money(currency: Currency.from(code: "GBP"), amount: 1000)
+        XCTAssertEqual(Money.from(1000, currencyCode: "GBP"), expected)
+    }
+
+    func test_fromEuroCode_shouldReturnExpectedValue() {
+        let expected = Money(currency: Currency.from(code: "EUR"), amount: 2000)
+        XCTAssertEqual(Money.from(2000, currencyCode: "EUR"), expected)
+    }
+
+    func test_fromUsdCode_ShouldReturnExpectedValue() {
+        let expected = Money(currency: Currency.from(code: "USD"), amount: 2000)
+        XCTAssertEqual(Money.from(2000, currencyCode: "USD"), expected)
+    }
+
+    func test_fromCadCode_ShouldReturnExpectedValue() {
+        let expected = Money(currency: Currency.from(code: "CAD"), amount: 2000)
+        XCTAssertEqual(Money.from(2000, currencyCode: "CAD"), expected)
+    }
+
+    func test_equatable_shouldReturnFalse_whenCurrencyDiffers() {
+        let first = Money.from(1000, currencyCode: "GBP")
+        let second = Money.from(1000, currencyCode: "EUR")
+        XCTAssertNotEqual(first, second)
+    }
+
+    func test_equatable_shouldReturnFalse_whenAmountDiffers() {
+        let first = Money.from(1000, currencyCode: "GBP")
+        let second = Money.from(1500, currencyCode: "GBP")
+        XCTAssertNotEqual(first, second)
+    }
+
+    func test_equatable_shouldReturnTrue_whenCurrencyAndAmountMatch() {
+        let first = Money(currencyCode: "EUR", amount: 5000)
+        let second = Money(currencyCode: "EUR", amount: 5000)
+        XCTAssertEqual(first, second)
+    }
+
+    func test_calculatePercentageAmount_shouldReturnExpectedValue_forWholeAmount() {
+        let initial = Money(currencyCode: "GBP", amount: 200)
+        let expected = Money(currencyCode: "GBP", amount: 120)
+        XCTAssertEqual(initial.calculatePercentageAmount(with: 60), expected)
+    }
+
+    func test_calculatePercentageAmount_shouldReturnExpectedValue_forRoundedAmount() {
+        let initial = Money(currencyCode: "GBP", amount: 45)
+        let expected = Money(currencyCode: "GBP", amount: 4)
+        XCTAssertEqual(initial.calculatePercentageAmount(with: 10), expected)
+    }
+
+    func test_subtractOperator_shouldReturnExpectedResult() {
+        let left = Money(currencyCode: "GBP", amount: 4500)
+        let right = Money(currencyCode: "GBP", amount: 1250)
+        let expected = Money(currencyCode: "GBP", amount: 3250)
+        XCTAssertEqual((left - right), expected)
+    }
+
+    func test_amountInMajorUnits_shouldReturnExpectedResultForGBP() {
+        let money = Money(currencyCode: "GBP", amount: 2576)
+        let expected = NSDecimalNumber(25.76)
+        XCTAssertEqual(money.amountInMajorUnits(), expected)
+    }
+
+    func test_amountInMajorUnits_shouldReturnExpectedResultForEUR() {
+        let money = Money(currencyCode: "EUR", amount: 3456)
+        let expected = NSDecimalNumber(34.56)
+        XCTAssertEqual(money.amountInMajorUnits(), expected)
+    }
+
+    func test_amountInMajorUnits_shouldReturnExpectedValueForUsd() {
+        let money = Money(currencyCode: "USD", amount: 5678)
+        let expected = NSDecimalNumber(56.78)
+        XCTAssertEqual(money.amountInMajorUnits(), expected)
+    }
+
+    func test_amountInMajorUnits_shouldReturnExpectedValueForCad() {
+        let money = Money(currencyCode: "CAD", amount: 3256)
+        let expected = NSDecimalNumber(32.56)
+        XCTAssertEqual(money.amountInMajorUnits(), expected)
+    }
+
+    func test_gt_shouldReturnFalseWhenExpected() {
+        let left = Money(currencyCode: "GBP", amount: 4500)
+        let right = Money(currencyCode: "GBP", amount: 4500)
+        XCTAssertFalse(left > right)
+    }
+
+    func test_gt_shouldReturnTrueWhenExpected() {
+        let left = Money(currencyCode: "GBP", amount: 4501)
+        let right = Money(currencyCode: "GBP", amount: 4500)
+        XCTAssertTrue(left > right)
+    }
+
+    func test_gt_withIntType_shouldReturnFalseWhenExpected() {
+        let left = Money(currencyCode: "GBP", amount: 4500)
+        XCTAssertFalse(left > 4500)
+    }
+
+    func test_gt_withIntType_shouldReturnTrueWhenExpected() {
+        let left = Money(currencyCode: "GBP", amount: 4501)
+        XCTAssertTrue(left > 4500)
+    }
+
+    func test_lt_shouldReturnFalseWhenExpected() {
+        let left = Money(currencyCode: "GBP", amount: 4500)
+        let right = Money(currencyCode: "GBP", amount: 4500)
+        XCTAssertFalse(left < right)
+    }
+
+    func test_lt_shouldReturnTrueWhenExpected() {
+        let left = Money(currencyCode: "GBP", amount: 4499)
+        let right = Money(currencyCode: "GBP", amount: 4500)
+        XCTAssertTrue(left < right)
+    }
+
+    func test_plusOperatorWithIntType_shouldCorrectlyAdd() {
+        let left = Money(currencyCode: "GBP", amount: 400)
+        let expected = Money(currencyCode: "GBP", amount: 900)
+        XCTAssertEqual(expected, left + 500)
+    }
+
+    func test_plusOperatorWithSameType_shouldCorrectlyAdd() {
+        let left = Money(currencyCode: "GBP", amount: 450)
+        let right = Money(currencyCode: "GBP", amount: 250)
+        let expected = Money(currencyCode: "GBP", amount: 700)
+        XCTAssertEqual(expected, left + right)
+    }
+
+    func test_plusOperatorwithNil_shouldAddZero() {
+        let left = Money(currencyCode: "GBP", amount: 450)
+        XCTAssertEqual(left, left + nil)
+    }
+
+    func test_multiplyOperatorWithLeftHandSide_shouldReturnExpectedResult() {
+        let left = Money(currencyCode: "GBP", amount: 450)
+        let expected = Money(currencyCode: "GBP", amount: 2250)
+        XCTAssertEqual(expected, 5 * left)
+    }
+
+    func test_multiplyOperatorWithRightHandSide_shouldReturnExpectedResult() {
+        let left = Money(currencyCode: "GBP", amount: 450)
+        let expected = Money(currencyCode: "GBP", amount: 2250)
+        XCTAssertEqual(expected, left * 5)
+    }
+}

--- a/RyftCoreTests/Models/PaymentSessionTests.swift
+++ b/RyftCoreTests/Models/PaymentSessionTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+
+@testable import RyftCore
+
+class PaymentSessionTests: XCTestCase {
+
+    func test_amountAsMoney_shouldReturnExpectedValue() {
+        let paymentSession = TestFixtures.paymentSession()
+        let expected = Money(
+            currencyCode: paymentSession.currency,
+            amount: paymentSession.amount
+        )
+        XCTAssertEqual(expected, paymentSession.amountAsMoney())
+    }
+}

--- a/RyftCoreTests/TestFixtures.swift
+++ b/RyftCoreTests/TestFixtures.swift
@@ -14,4 +14,17 @@ final class TestFixtures {
             createdTimestamp: 123
         )
     }
+
+    static func billingAddress() -> BillingAddress {
+        BillingAddress(
+            firstName: nil,
+            lastName: nil,
+            lineOne: nil,
+            lineTwo: nil,
+            city: nil,
+            country: "US",
+            postalCode: "94043",
+            region: nil
+        )
+    }
 }

--- a/RyftCoreTests/TestFixtures.swift
+++ b/RyftCoreTests/TestFixtures.swift
@@ -5,6 +5,8 @@ final class TestFixtures {
     static func paymentSession() -> PaymentSession {
         return PaymentSession(
             id: "ps_01FCTS1XMKH9FF43CAFA4CXT3P",
+            amount: 350,
+            currency: "GBP",
             status: .approved,
             lastError: nil,
             requiredAction: nil,

--- a/RyftCoreTests/Utility/CurrencyUtilityTests.swift
+++ b/RyftCoreTests/Utility/CurrencyUtilityTests.swift
@@ -1,0 +1,678 @@
+import XCTest
+
+@testable import RyftCore
+
+// swiftlint:disable file_length
+class CurrencyUtilityTests: XCTestCase {
+
+    // see: https://en.wikipedia.org/wiki/ISO_4217
+
+    func test_AED_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "AED"))
+    }
+
+    func test_AFN_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "AFN"))
+    }
+
+    func test_ALL_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "ALL"))
+    }
+
+    func test_AMD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "AMD"))
+    }
+
+    func test_ANG_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "ANG"))
+    }
+
+    func test_AOA_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "AOA"))
+    }
+
+    func test_ARS_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "ARS"))
+    }
+
+    func test_AUD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "AUD"))
+    }
+
+    func test_AWG_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "AWG"))
+    }
+
+    func test_AZN_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "AZN"))
+    }
+
+    func test_BAM_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "BAM"))
+    }
+
+    func test_BBD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "BBD"))
+    }
+
+    func test_BDT_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "BDT"))
+    }
+
+    func test_BGN_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "BGN"))
+    }
+
+    func test_BHD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(3, CurrencyUtility.minorUnits(from: "BHD"))
+    }
+
+    func test_BIF_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(0, CurrencyUtility.minorUnits(from: "BIF"))
+    }
+
+    func test_BMD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "BMD"))
+    }
+
+    func test_BND_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "BND"))
+    }
+
+    func test_BOB_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "BOB"))
+    }
+
+    func test_BOV_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "BOV"))
+    }
+
+    func test_BRL_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "BRL"))
+    }
+
+    func test_BSD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "BSD"))
+    }
+
+    func test_BTN_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "BTN"))
+    }
+
+    func test_BWP_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "BWP"))
+    }
+
+    func test_BYN_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "BYN"))
+    }
+
+    func test_BZD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "BZD"))
+    }
+
+    func test_CAD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "CAD"))
+    }
+
+    func test_CDF_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "CDF"))
+    }
+
+    func test_CHE_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "CHE"))
+    }
+
+    func test_CHF_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "CHF"))
+    }
+
+    func test_CHW_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "CHW"))
+    }
+
+    func test_CLF_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(4, CurrencyUtility.minorUnits(from: "CLF"))
+    }
+
+    func test_CLP_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(0, CurrencyUtility.minorUnits(from: "CLP"))
+    }
+
+    func test_CNY_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "CNY"))
+    }
+
+    func test_COP_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "COP"))
+    }
+
+    func test_COU_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "COU"))
+    }
+
+    func test_CRC_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "CRC"))
+    }
+
+    func test_CUC_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "CUC"))
+    }
+
+    func test_CUP_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "CUP"))
+    }
+
+    func test_CVE_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "CVE"))
+    }
+
+    func test_CZK_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "CZK"))
+    }
+
+    func test_DJF_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(0, CurrencyUtility.minorUnits(from: "DJF"))
+    }
+
+    func test_DKK_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "DKK"))
+    }
+
+    func test_DOP_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "DOP"))
+    }
+
+    func test_DZD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "DZD"))
+    }
+
+    func test_EGP_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "EGP"))
+    }
+
+    func test_ERN_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "ERN"))
+    }
+
+    func test_ETB_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "ETB"))
+    }
+
+    func test_EUR_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "EUR"))
+    }
+
+    func test_FJD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "FJD"))
+    }
+
+    func test_FKP_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "FKP"))
+    }
+
+    func test_GBP_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "GBP"))
+    }
+
+    func test_GEL_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "GEL"))
+    }
+
+    func test_GHS_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "GHS"))
+    }
+
+    func test_GIP_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "GIP"))
+    }
+
+    func test_GMD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "GMD"))
+    }
+
+    func test_GNF_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(0, CurrencyUtility.minorUnits(from: "GNF"))
+    }
+
+    func test_GTQ_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "GTQ"))
+    }
+
+    func test_GYD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "GYD"))
+    }
+
+    func test_HKD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "HKD"))
+    }
+
+    func test_HNL_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "HNL"))
+    }
+
+    func test_HRK_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "HRK"))
+    }
+
+    func test_HTG_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "HTG"))
+    }
+
+    func test_HUF_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "HUF"))
+    }
+
+    func test_IDR_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "IDR"))
+    }
+
+    func test_ILS_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "ILS"))
+    }
+
+    func test_INR_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "INR"))
+    }
+
+    func test_IQD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(3, CurrencyUtility.minorUnits(from: "IQD"))
+    }
+
+    func test_IRR_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "IRR"))
+    }
+
+    func test_ISK_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(0, CurrencyUtility.minorUnits(from: "ISK"))
+    }
+
+    func test_JMD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "JMD"))
+    }
+
+    func test_JOD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(3, CurrencyUtility.minorUnits(from: "JOD"))
+    }
+
+    func test_JPY_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(0, CurrencyUtility.minorUnits(from: "JPY"))
+    }
+
+    func test_KES_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "KES"))
+    }
+
+    func test_KGS_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "KGS"))
+    }
+
+    func test_KHR_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "KHR"))
+    }
+
+    func test_KMF_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(0, CurrencyUtility.minorUnits(from: "KMF"))
+    }
+
+    func test_KPW_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "KPW"))
+    }
+
+    func test_KRW_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(0, CurrencyUtility.minorUnits(from: "KRW"))
+    }
+
+    func test_KWD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(3, CurrencyUtility.minorUnits(from: "KWD"))
+    }
+
+    func test_KYD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "KYD"))
+    }
+
+    func test_KZT_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "KZT"))
+    }
+
+    func test_LAK_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "LAK"))
+    }
+
+    func test_LBP_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "LBP"))
+    }
+
+    func test_LKR_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "LKR"))
+    }
+
+    func test_LRD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "LRD"))
+    }
+
+    func test_LSL_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "LSL"))
+    }
+
+    func test_LYD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(3, CurrencyUtility.minorUnits(from: "LYD"))
+    }
+
+    func test_MAD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "MAD"))
+    }
+
+    func test_MDL_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "MDL"))
+    }
+
+    func test_MGA_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "MGA"))
+    }
+
+    func test_MKD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "MKD"))
+    }
+
+    func test_MMK_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "MMK"))
+    }
+
+    func test_MNT_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "MNT"))
+    }
+
+    func test_MOP_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "MOP"))
+    }
+
+    func test_MRU_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "MRU"))
+    }
+
+    func test_MUR_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "MUR"))
+    }
+
+    func test_MVR_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "MVR"))
+    }
+
+    func test_MWK_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "MWK"))
+    }
+
+    func test_MXN_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "MXN"))
+    }
+
+    func test_MXV_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "MXV"))
+    }
+
+    func test_MYR_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "MYR"))
+    }
+
+    func test_MZN_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "MZN"))
+    }
+
+    func test_NAD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "NAD"))
+    }
+
+    func test_NGN_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "NGN"))
+    }
+
+    func test_NIO_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "NIO"))
+    }
+
+    func test_NOK_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "NOK"))
+    }
+
+    func test_NPR_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "NPR"))
+    }
+
+    func test_NZD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "NZD"))
+    }
+
+    func test_OMR_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(3, CurrencyUtility.minorUnits(from: "OMR"))
+    }
+
+    func test_PAB_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "PAB"))
+    }
+
+    func test_PEN_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "PEN"))
+    }
+
+    func test_PGK_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "PGK"))
+    }
+
+    func test_PHP_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "PHP"))
+    }
+
+    func test_PKR_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "PKR"))
+    }
+
+    func test_PLN_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "PLN"))
+    }
+
+    func test_PYG_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(0, CurrencyUtility.minorUnits(from: "PYG"))
+    }
+
+    func test_QAR_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "QAR"))
+    }
+
+    func test_RON_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "RON"))
+    }
+
+    func test_RSD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "RSD"))
+    }
+
+    func test_RUB_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "RUB"))
+    }
+
+    func test_RWF_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(0, CurrencyUtility.minorUnits(from: "RWF"))
+    }
+
+    func test_SAR_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "SAR"))
+    }
+
+    func test_SBD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "SBD"))
+    }
+
+    func test_SCR_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "SCR"))
+    }
+
+    func test_SDG_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "SDG"))
+    }
+
+    func test_SEK_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "SEK"))
+    }
+
+    func test_SGD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "SGD"))
+    }
+
+    func test_SHP_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "SHP"))
+    }
+
+    func test_SLL_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "SLL"))
+    }
+
+    func test_SOS_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "SOS"))
+    }
+
+    func test_SRD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "SRD"))
+    }
+
+    func test_SSP_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "SSP"))
+    }
+
+    func test_STN_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "STN"))
+    }
+
+    func test_SVC_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "SVC"))
+    }
+
+    func test_SYP_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "SYP"))
+    }
+
+    func test_SZL_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "SZL"))
+    }
+
+    func test_THB_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "THB"))
+    }
+
+    func test_TJS_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "TJS"))
+    }
+
+    func test_TMT_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "TMT"))
+    }
+
+    func test_TND_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(3, CurrencyUtility.minorUnits(from: "TND"))
+    }
+
+    func test_TOP_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "TOP"))
+    }
+
+    func test_TRY_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "TRY"))
+    }
+
+    func test_TTD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "TTD"))
+    }
+
+    func test_TWD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "TWD"))
+    }
+
+    func test_TZS_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "TZS"))
+    }
+
+    func test_UAH_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "UAH"))
+    }
+
+    func test_UGX_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(0, CurrencyUtility.minorUnits(from: "UGX"))
+    }
+
+    func test_USD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "USD"))
+    }
+
+    func test_USN_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "USN"))
+    }
+
+    func test_UYI_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(0, CurrencyUtility.minorUnits(from: "UYI"))
+    }
+
+    func test_UYU_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "UYU"))
+    }
+
+    func test_UYW_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(4, CurrencyUtility.minorUnits(from: "UYW"))
+    }
+
+    func test_UZS_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "UZS"))
+    }
+
+    func test_VED_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "VED"))
+    }
+
+    func test_VES_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "VES"))
+    }
+
+    func test_VND_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(0, CurrencyUtility.minorUnits(from: "VND"))
+    }
+
+    func test_VUV_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(0, CurrencyUtility.minorUnits(from: "VUV"))
+    }
+
+    func test_WST_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "WST"))
+    }
+
+    func test_XAF_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(0, CurrencyUtility.minorUnits(from: "XAF"))
+    }
+
+    func test_XCD_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "XCD"))
+    }
+
+    func test_XOF_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(0, CurrencyUtility.minorUnits(from: "XOF"))
+    }
+
+    func test_XPF_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(0, CurrencyUtility.minorUnits(from: "XPF"))
+    }
+
+    func test_YER_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "YER"))
+    }
+
+    func test_ZAR_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "ZAR"))
+    }
+
+    func test_ZMW_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "ZMW"))
+    }
+
+    func test_ZWL_shouldReturnExpectedMinorUnits() {
+        XCTAssertEqual(2, CurrencyUtility.minorUnits(from: "ZWL"))
+    }
+}
+// swiftlint:enable file_length

--- a/ryft-ios.xcodeproj/project.pbxproj
+++ b/ryft-ios.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		D868930927A2BF5C003DBFAA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D868930727A2BF5C003DBFAA /* Localizable.strings */; };
 		D868930D27A2BF7B003DBFAA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D868930B27A2BF7B003DBFAA /* Localizable.strings */; };
 		D89384992836759500F67926 /* PaymentSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89384982836759500F67926 /* PaymentSessionTests.swift */; };
+		D893849B283677E400F67926 /* BillingAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = D893849A283677E400F67926 /* BillingAddress.swift */; };
+		D893849D283679B200F67926 /* BillingAddressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D893849C283679B200F67926 /* BillingAddressTests.swift */; };
 		D8AB659C28367393009EF72C /* Currency.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB659B28367393009EF72C /* Currency.swift */; };
 		D8AB659F283673BC009EF72C /* CurrencyUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB659E283673BC009EF72C /* CurrencyUtility.swift */; };
 		D8AB65A228367403009EF72C /* CurrencyUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB65A128367403009EF72C /* CurrencyUtilityTests.swift */; };
@@ -232,6 +234,8 @@
 		D868930827A2BF5C003DBFAA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = Localizable.strings; sourceTree = "<group>"; };
 		D868930C27A2BF7B003DBFAA /* en-gb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-gb"; path = Localizable.strings; sourceTree = "<group>"; };
 		D89384982836759500F67926 /* PaymentSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSessionTests.swift; sourceTree = "<group>"; };
+		D893849A283677E400F67926 /* BillingAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingAddress.swift; sourceTree = "<group>"; };
+		D893849C283679B200F67926 /* BillingAddressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingAddressTests.swift; sourceTree = "<group>"; };
 		D8AB659B28367393009EF72C /* Currency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Currency.swift; sourceTree = "<group>"; };
 		D8AB659E283673BC009EF72C /* CurrencyUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyUtility.swift; sourceTree = "<group>"; };
 		D8AB65A128367403009EF72C /* CurrencyUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyUtilityTests.swift; sourceTree = "<group>"; };
@@ -479,6 +483,7 @@
 				D86892A627A2A961003DBFAA /* RyftApiClient.swift */,
 				D86892A827A2A973003DBFAA /* RyftApiError.swift */,
 				D86892AA27A2A98C003DBFAA /* RyftHttpClient.swift */,
+				D893849A283677E400F67926 /* BillingAddress.swift */,
 			);
 			path = Api;
 			sourceTree = "<group>";
@@ -650,6 +655,7 @@
 				D8F1638427A2E6970076CC02 /* DefaultRyftApiClientTests.swift */,
 				D8F1638627A2E6B50076CC02 /* MockHttpClient.swift */,
 				D8F1638827A2E7040076CC02 /* EndpointTest.swift */,
+				D893849C283679B200F67926 /* BillingAddressTests.swift */,
 			);
 			path = Api;
 			sourceTree = "<group>";
@@ -1056,6 +1062,7 @@
 				D868929D27A2A8FE003DBFAA /* DefaultRyftApiClient.swift in Sources */,
 				D86892A127A2A924003DBFAA /* HttpClient.swift in Sources */,
 				D868929B27A2A8E4003DBFAA /* AttemptPaymentRequest.swift in Sources */,
+				D893849B283677E400F67926 /* BillingAddress.swift in Sources */,
 				D868929227A2A86E003DBFAA /* PaymentSessionError.swift in Sources */,
 				D86892AB27A2A98C003DBFAA /* RyftHttpClient.swift in Sources */,
 				D868929627A2A894003DBFAA /* PaymentSessionRequiredAction.swift in Sources */,
@@ -1110,6 +1117,7 @@
 			files = (
 				D8F1638727A2E6B50076CC02 /* MockHttpClient.swift in Sources */,
 				D8F1638327A2E6700076CC02 /* AttemptPaymentRequestTest.swift in Sources */,
+				D893849D283679B200F67926 /* BillingAddressTests.swift in Sources */,
 				D8F1638927A2E7040076CC02 /* EndpointTest.swift in Sources */,
 				D8F1638027A2E63A0076CC02 /* TestFixtures.swift in Sources */,
 				D8AB65A828367466009EF72C /* CurrencyTests.swift in Sources */,

--- a/ryft-ios.xcodeproj/project.pbxproj
+++ b/ryft-ios.xcodeproj/project.pbxproj
@@ -59,6 +59,13 @@
 		D868930227A2BE76003DBFAA /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D868930127A2BE76003DBFAA /* Images.xcassets */; };
 		D868930927A2BF5C003DBFAA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D868930727A2BF5C003DBFAA /* Localizable.strings */; };
 		D868930D27A2BF7B003DBFAA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D868930B27A2BF7B003DBFAA /* Localizable.strings */; };
+		D89384992836759500F67926 /* PaymentSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89384982836759500F67926 /* PaymentSessionTests.swift */; };
+		D8AB659C28367393009EF72C /* Currency.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB659B28367393009EF72C /* Currency.swift */; };
+		D8AB659F283673BC009EF72C /* CurrencyUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB659E283673BC009EF72C /* CurrencyUtility.swift */; };
+		D8AB65A228367403009EF72C /* CurrencyUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB65A128367403009EF72C /* CurrencyUtilityTests.swift */; };
+		D8AB65A828367466009EF72C /* CurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB65A728367466009EF72C /* CurrencyTests.swift */; };
+		D8AB65AA283674E9009EF72C /* MoneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB65A9283674E9009EF72C /* MoneyTests.swift */; };
+		D8AB65AC283674FE009EF72C /* Money.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB65AB283674FE009EF72C /* Money.swift */; };
 		D8F1635D27A2DB460076CC02 /* RyftCard.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D868924C27A2A3E8003DBFAA /* RyftCard.framework */; };
 		D8F1636427A2DC030076CC02 /* TestFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F1636327A2DC030076CC02 /* TestFixtures.swift */; };
 		D8F1636627A2DD3F0076CC02 /* RyftCardFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F1636527A2DD3F0076CC02 /* RyftCardFormatterTests.swift */; };
@@ -224,6 +231,13 @@
 		D868930127A2BE76003DBFAA /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		D868930827A2BF5C003DBFAA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = Localizable.strings; sourceTree = "<group>"; };
 		D868930C27A2BF7B003DBFAA /* en-gb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-gb"; path = Localizable.strings; sourceTree = "<group>"; };
+		D89384982836759500F67926 /* PaymentSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSessionTests.swift; sourceTree = "<group>"; };
+		D8AB659B28367393009EF72C /* Currency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Currency.swift; sourceTree = "<group>"; };
+		D8AB659E283673BC009EF72C /* CurrencyUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyUtility.swift; sourceTree = "<group>"; };
+		D8AB65A128367403009EF72C /* CurrencyUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyUtilityTests.swift; sourceTree = "<group>"; };
+		D8AB65A728367466009EF72C /* CurrencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyTests.swift; sourceTree = "<group>"; };
+		D8AB65A9283674E9009EF72C /* MoneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoneyTests.swift; sourceTree = "<group>"; };
+		D8AB65AB283674FE009EF72C /* Money.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Money.swift; sourceTree = "<group>"; };
 		D8F1635827A2DB460076CC02 /* RyftCardTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RyftCardTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D8F1635C27A2DB460076CC02 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D8F1636327A2DC030076CC02 /* TestFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestFixtures.swift; sourceTree = "<group>"; };
@@ -422,6 +436,7 @@
 		D868927F27A2A4F2003DBFAA /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				D8AB659D283673AC009EF72C /* Utility */,
 				D868929927A2A8D4003DBFAA /* Api */,
 				D868928E27A2A836003DBFAA /* Models */,
 				D868928C27A2A82E003DBFAA /* Constants.swift */,
@@ -446,6 +461,8 @@
 				D868929127A2A86E003DBFAA /* PaymentSessionError.swift */,
 				D868929527A2A894003DBFAA /* PaymentSessionRequiredAction.swift */,
 				D868929727A2A8AA003DBFAA /* PaymentSessionStatus.swift */,
+				D8AB659B28367393009EF72C /* Currency.swift */,
+				D8AB65AB283674FE009EF72C /* Money.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -566,6 +583,32 @@
 			path = "en-gb.lproj";
 			sourceTree = "<group>";
 		};
+		D8AB659D283673AC009EF72C /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				D8AB659E283673BC009EF72C /* CurrencyUtility.swift */,
+			);
+			path = Utility;
+			sourceTree = "<group>";
+		};
+		D8AB65A0283673EC009EF72C /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				D8AB65A128367403009EF72C /* CurrencyUtilityTests.swift */,
+			);
+			path = Utility;
+			sourceTree = "<group>";
+		};
+		D8AB65A62836744E009EF72C /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				D8AB65A728367466009EF72C /* CurrencyTests.swift */,
+				D8AB65A9283674E9009EF72C /* MoneyTests.swift */,
+				D89384982836759500F67926 /* PaymentSessionTests.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		D8F1635927A2DB460076CC02 /* RyftCardTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -591,6 +634,8 @@
 		D8F1637527A2E43F0076CC02 /* RyftCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				D8AB65A62836744E009EF72C /* Models */,
+				D8AB65A0283673EC009EF72C /* Utility */,
 				D8F1638127A2E6590076CC02 /* Api */,
 				D8F1637827A2E43F0076CC02 /* Info.plist */,
 				D8F1637F27A2E63A0076CC02 /* TestFixtures.swift */,
@@ -1005,6 +1050,8 @@
 				D86892A327A2A938003DBFAA /* HttpError.swift in Sources */,
 				D868929F27A2A911003DBFAA /* Endpoint.swift in Sources */,
 				D86892A927A2A973003DBFAA /* RyftApiError.swift in Sources */,
+				D8AB659C28367393009EF72C /* Currency.swift in Sources */,
+				D8AB65AC283674FE009EF72C /* Money.swift in Sources */,
 				D86892A527A2A94A003DBFAA /* HttpMethod.swift in Sources */,
 				D868929D27A2A8FE003DBFAA /* DefaultRyftApiClient.swift in Sources */,
 				D86892A127A2A924003DBFAA /* HttpClient.swift in Sources */,
@@ -1013,6 +1060,7 @@
 				D86892AB27A2A98C003DBFAA /* RyftHttpClient.swift in Sources */,
 				D868929627A2A894003DBFAA /* PaymentSessionRequiredAction.swift in Sources */,
 				D868929027A2A851003DBFAA /* PaymentSession.swift in Sources */,
+				D8AB659F283673BC009EF72C /* CurrencyUtility.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1064,7 +1112,11 @@
 				D8F1638327A2E6700076CC02 /* AttemptPaymentRequestTest.swift in Sources */,
 				D8F1638927A2E7040076CC02 /* EndpointTest.swift in Sources */,
 				D8F1638027A2E63A0076CC02 /* TestFixtures.swift in Sources */,
+				D8AB65A828367466009EF72C /* CurrencyTests.swift in Sources */,
 				D8F1638527A2E6970076CC02 /* DefaultRyftApiClientTests.swift in Sources */,
+				D8AB65AA283674E9009EF72C /* MoneyTests.swift in Sources */,
+				D89384992836759500F67926 /* PaymentSessionTests.swift in Sources */,
+				D8AB65A228367403009EF72C /* CurrencyUtilityTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This change simply updates the core module to reflect the full API spec:
 - walletDetails (for ApplePay)
 - billingAddress