### PR TITLE
[Tech] - add .cancelled value on RyftPaymentResult

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -83,7 +83,7 @@ type_body_length:
   error: 520
 
 file_length:
-  warning: 575
+  warning: 600
   error: 600
 
 function_body_length:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This method is invoked once the customer has entered their payment method detail
 func onPaymentResult(result: RyftPaymentResult) {
     switch result {
     // payment approved, send the customer to your receipt/success view
-    case .success:
+    case .success(let paymentSession):
         showSuccessView()
     // payment requires an additional action in order to be approved (e.g. 3ds)
     case .pendingAction(let paymentSession, let requiredAction):
@@ -100,6 +100,9 @@ func onPaymentResult(result: RyftPaymentResult) {
         })
         present(alert, animated: true, completion: nil)
     }
+    // drop in was cancelled prior to attempting payment
+    case .cancelled:
+        // you may want to log that the payment was cancelled here
 }
 ```
 

--- a/RyftUI/Source/Controllers/Animation/SlidingAnimator.swift
+++ b/RyftUI/Source/Controllers/Animation/SlidingAnimator.swift
@@ -7,13 +7,21 @@ final class SlidingAnimator: NSObject, UIViewControllerAnimatedTransitioning {
         case dismissing
     }
 
-    private var duration: CGFloat = 0.4
+    private static let defaultDuration: CGFloat = 0.4
+
+    private var duration: CGFloat = defaultDuration
     private var animationType = AnimationType.presenting
+    private var onComplete: (() -> Void)?
     private var originFrame = CGRect.zero
 
-    init(duration: CGFloat, animationType: AnimationType) {
+    init(
+        duration: CGFloat,
+        animationType: AnimationType,
+        onComplete: (() -> Void)? = nil
+    ) {
         self.duration = duration
         self.animationType = animationType
+        self.onComplete = onComplete
     }
 
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
@@ -67,7 +75,20 @@ final class SlidingAnimator: NSObject, UIViewControllerAnimatedTransitioning {
             },
             completion: { _ in
                 transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
+                self.onComplete?()
             }
+        )
+    }
+
+    static func presentingAnimator() -> SlidingAnimator {
+        SlidingAnimator(duration: defaultDuration, animationType: .presenting)
+    }
+
+    static func dismissAnimator(onComplete: (() -> Void)? = nil) -> SlidingAnimator {
+        SlidingAnimator(
+            duration: defaultDuration,
+            animationType: .dismissing,
+            onComplete: onComplete
         )
     }
 }

--- a/RyftUI/Source/Controllers/Animation/SlidingTransitioningHandler.swift
+++ b/RyftUI/Source/Controllers/Animation/SlidingTransitioningHandler.swift
@@ -2,8 +2,8 @@ import UIKit
 
 final class SlidingTransitioningHandler: NSObject, UIViewControllerTransitioningDelegate {
 
-    private let presenterTransition = SlidingAnimator(duration: 0.4, animationType: .presenting)
-    private let dismissTransition = SlidingAnimator(duration: 0.4, animationType: .dismissing)
+    private var presenterTransition = SlidingAnimator.presentingAnimator()
+    private var dismissTransition = SlidingAnimator.dismissAnimator()
     private weak var presentedViewController: UIViewController?
 
     var height: CGFloat {
@@ -30,6 +30,17 @@ final class SlidingTransitioningHandler: NSObject, UIViewControllerTransitioning
         self.height = height
         self.userInteractionEnabled = true
         self.presentedViewController = presentedViewController
+    }
+
+    init(
+        presentedViewController: UIViewController,
+        height: CGFloat,
+        dismissTransition: SlidingAnimator
+    ) {
+        self.height = height
+        self.userInteractionEnabled = true
+        self.presentedViewController = presentedViewController
+        self.dismissTransition = dismissTransition
     }
 
     func presentationController(

--- a/RyftUI/Source/Controllers/RyftDropInPaymentViewController.swift
+++ b/RyftUI/Source/Controllers/RyftDropInPaymentViewController.swift
@@ -159,10 +159,7 @@ public final class RyftDropInPaymentViewController: UIViewController {
         self.delegate = delegate
         self.apiClient = DefaultRyftApiClient(publicApiKey: publicApiKey)
         super.init(nibName: nil, bundle: nil)
-        self.transitionHandler = SlidingTransitioningHandler(
-            presentedViewController: self,
-            height: estimatedHeight
-        )
+        self.transitionHandler = initTransitionHandler()
         transitioningDelegate = self.transitionHandler
         modalPresentationStyle = .custom
     }
@@ -180,8 +177,21 @@ public final class RyftDropInPaymentViewController: UIViewController {
             presentedViewController: self,
             height: estimatedHeight
         )
+        self.transitionHandler = initTransitionHandler()
         transitioningDelegate = self.transitionHandler
         modalPresentationStyle = .custom
+    }
+
+    private func initTransitionHandler() -> SlidingTransitioningHandler {
+        SlidingTransitioningHandler(
+            presentedViewController: self,
+            height: estimatedHeight,
+            dismissTransition: SlidingAnimator.dismissAnimator(
+                onComplete: {
+                    self.invokeDelegate(with: .cancelled, shouldDismiss: false)
+                }
+            )
+        )
     }
 
     deinit {

--- a/RyftUI/Source/Models/RyftPaymentResult.swift
+++ b/RyftUI/Source/Models/RyftPaymentResult.swift
@@ -1,6 +1,7 @@
 import RyftCore
 
 public enum RyftPaymentResult {
+    case cancelled
     case failed(error: RyftPaymentError)
     case pendingAction(
         paymentSession: PaymentSession,

--- a/RyftUITestApp/ViewController.swift
+++ b/RyftUITestApp/ViewController.swift
@@ -272,6 +272,8 @@ extension ViewController: RyftDropInPaymentDelegate {
         var title = "Payment Failed"
         var message = "failure"
         switch result {
+        case .cancelled:
+            title = "Payment Cancelled"
         case .failed(let error):
             message = error.displayError
         case .success(let paymentSession):

--- a/RyftUITests/RyftDropInPaymentViewControllerTests.swift
+++ b/RyftUITests/RyftDropInPaymentViewControllerTests.swift
@@ -161,6 +161,13 @@ final class RyftDropInPaymentViewControllerTests: XCTestCase {
         XCTAssertFalse(app.buttons["RyftButton-Cancel"].exists)
     }
 
+    func test_dropIn_shouldReturnCancelledResult_whenClickingCancelOnDropIn() {
+        openDropIn()
+        let cancelButton = app.buttons["RyftButton-Cancel"]
+        cancelButton.tap()
+        XCTAssertTrue(app.alerts.element.staticTexts["Payment Cancelled"].waitForExistence(timeout: 5))
+    }
+
     func test_dropIn_shouldDisplayAlert_whenCardPaymentFails() {
         app.segmentedControls["FailPaymentControl"].buttons.element(boundBy: 0).forceTap()
         openDropIn()


### PR DESCRIPTION
Adds an additional `.cancelled` value on the `RyftPaymentResult` so that actions can be run off the back of the drop in being cancelled.